### PR TITLE
Fix #250

### DIFF
--- a/ios/ReactNativePageView.m
+++ b/ios/ReactNativePageView.m
@@ -45,15 +45,6 @@
     return self;
 }
 
-- (void)layoutSubviews {
-    [super layoutSubviews];
-    if (self.reactPageViewController) {
-        [self shouldScroll:self.scrollEnabled];
-        //Below line fix bug, where the view does not update after orientation changed.
-        [self updateDataSource];
-    }
-}
-
 - (void)didUpdateReactSubviews {
     if (!self.reactPageViewController && self.reactViewController != nil) {
         [self embed];


### PR DESCRIPTION
# Summary

Fix #250.
This [method](https://github.com/callstack/react-native-viewpager/blob/master/ios/ReactNativePageView.m#L48-L55) seems unnecessary, had tested in orientation changing case, everything works fine without it.
But it will cause focus lose when subview layout changes.

### What's required for testing (prerequisites)?
Check if ViewPager changes its layout after orientation changed.

### What are the steps to reproduce (after prerequisites)?
https://github.com/callstack/react-native-viewpager/issues/155


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅  |

## Checklist

- [X] I have tested this on a device and a simulator
